### PR TITLE
Use os.environ instead of subprocess call

### DIFF
--- a/operations/phomology.py
+++ b/operations/phomology.py
@@ -1,33 +1,35 @@
 
 ##################################################################################
-# Persistent homology calculation                                                                    #  
+# Persistent homology calculation                                                                    #
 ##################################################################################
 
 def persistent_homology_calculation(clique_dictionary_file,max_homology_dimension,dataset_tag, output_dir,jython_call="jython ", script_dir=None, m1=2048,m2=2048,javaplex_directory=None,save_generators=False):
     import os, sys
     import Holes
     from subprocess import call
-    mem_options='JAVA_OPTIONS="-Xms'+str(m1)+'m -Xmx'+str(m2)+'m" ';  
-        
+
+    os.environ["JAVA_OPTIONS"] = "-Xms"+str(m1)+"m -Xmx"+str(m2)+"m"
+    os.environ["JAVA_OPTS"]    = "-Xms"+str(m1)+"m -Xmx"+str(m2)+"m"
+
     if script_dir==None:
         diodir = os.path.dirname(Holes.__file__)
         script = diodir+'/jython_utils/persistent_homology_calculation.py';
     else:
         script = script_dir + '/jython_utils/persistent_homology_calculation.py';
-    
+
     if javaplex_directory==None:
             diodir =   os.path.dirname(Holes.__file__)
             javaplex_directory = diodir+'/jython_utils/lib/';
-    
+
     #here goes the modified jython script
 
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
     #file to be called
-    print 'Calling: '+ mem_options + jython_call+" "+script+" "+clique_dictionary_file+' '+str(max_homology_dimension)+" "+output_dir+" "+dataset_tag+"_ "+javaplex_directory+' '+str(save_generators);
+    print 'Calling: ' + jython_call+" "+script+" "+clique_dictionary_file+' '+str(max_homology_dimension)+" "+output_dir+" "+dataset_tag+"_ "+javaplex_directory+' '+str(save_generators);
 
     try:
-        retcode = call(mem_options + jython_call+" "+script+" "+clique_dictionary_file+' '+str(max_homology_dimension)+" "+output_dir+" "+dataset_tag+"_ "+javaplex_directory+' '+str(save_generators), shell=True)
+        retcode = call(jython_call+" "+script+" "+clique_dictionary_file+' '+str(max_homology_dimension)+" "+output_dir+" "+dataset_tag+"_ "+javaplex_directory+' '+str(save_generators), shell=True)
         if retcode < 0:
             print >>sys.stderr, "Child was terminated by signal", -retcode
         else:
@@ -39,27 +41,29 @@ def persistent_cohomology_calculation(clique_dictionary_file,max_homology_dimens
     import os, sys
     import Holes
     from subprocess import call
-    mem_options='JAVA_OPTIONS="-Xms'+str(m1)+'m -Xmx'+str(m2)+'m" ';
-        
+
+    os.environ["JAVA_OPTIONS"] = "-Xms"+str(m1)+"m -Xmx"+str(m2)+"m"
+    os.environ["JAVA_OPTS"]    = "-Xms"+str(m1)+"m -Xmx"+str(m2)+"m"
+
     if script_dir==None:
         diodir = os.path.dirname(Holes.__file__)
         script = diodir+'/jython_utils/persistent_cohomology_calculation.py';
     else:
         script = script_dir + '/jython_utils/persistent_cohomology_calculation.py';
-    
+
     if javaplex_directory==None:
             diodir =   os.path.dirname(Holes.__file__)
             javaplex_directory = diodir+'/jython_utils/lib/';
-    
+
     #here goes the modified jython script
 
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
     #file to be called
-    print 'Calling: '+mem_options + jython_call+" "+script+" "+clique_dictionary_file+' '+str(max_homology_dimension)+" "+output_dir+" "+dataset_tag+"_ "+javaplex_directory;
+    print 'Calling: ' + jython_call+" "+script+" "+clique_dictionary_file+' '+str(max_homology_dimension)+" "+output_dir+" "+dataset_tag+"_ "+javaplex_directory;
 
     try:
-        retcode = call(mem_options + jython_call+" "+script+" "+clique_dictionary_file+' '+str(max_homology_dimension)+" "+output_dir+" "+dataset_tag+"_ "+javaplex_directory, shell=True)
+        retcode = call(jython_call+" "+script+" "+clique_dictionary_file+' '+str(max_homology_dimension)+" "+output_dir+" "+dataset_tag+"_ "+javaplex_directory, shell=True)
         if retcode < 0:
             print >>sys.stderr, "Child was terminated by signal", -retcode
         else:


### PR DESCRIPTION
When we were using Holes on a Windows machine the `JAVA_OPTIONS` shell variable caused the functions incorporating it to break.

Using `os.environ` to set environment variables is a more general solution to the problem and works across all platforms. Therefore, I have cut `JAVA_OPTIONS` in favour of `os.environ`.
